### PR TITLE
Frequency generator can work as a shell script

### DIFF
--- a/memristive_spinal_cord/afferents/frequency/list.py
+++ b/memristive_spinal_cord/afferents/frequency/list.py
@@ -32,7 +32,7 @@ class FrequencyList:
 
             # fraction used as a probability of the additional spike
             if self.interval / 1000 * frequency - spikes_at_interval > random.random():
-                spikes_at_interval = spikes_at_interval + 1
+                spikes_at_interval += 1
 
             if spikes_at_interval > 0:
                 time_between_spikes = self.interval / spikes_at_interval

--- a/memristive_spinal_cord/afferents/frequency/test_generator.py
+++ b/memristive_spinal_cord/afferents/frequency/test_generator.py
@@ -1,6 +1,8 @@
 import math
+import sys
+import os
+sys.path.insert(0, '/'.join(os.getcwd().split('/')[:-3]))
 from memristive_spinal_cord.afferents.frequency.list_generator import FrequencyListGenerator
-from memristive_spinal_cord.afferents.frequency.list import FrequencyList
 
 
 class TestGenerator(FrequencyListGenerator):
@@ -11,8 +13,14 @@ class TestGenerator(FrequencyListGenerator):
         self.frequencies = [5, 15, 50]
 
 
-testTime = 10
-testInterval = 100
+if __name__ == '__main__':
+    assert len(sys.argv) == 3, '2 arguments needed simulation time and interval'
+    testTime = int(sys.argv[1])
+    testInterval = int(sys.argv[2])
+else:
+    testTime = 1
+    testInterval = 20
+
 testGenerator = TestGenerator()
 frequencyList = testGenerator.generate(testTime, testInterval)
 spikeList = frequencyList.generate_spikes()
@@ -34,6 +42,6 @@ acceptableErrorNumberOfSpikes = 2
 for i in range(numberOfIntervals):
     intervalFrequency = frequencyList.list[i] / numberOfIntervals * testTime
     assert math.fabs(intervalFrequency - spikesPerInterval[i]) < acceptableErrorNumberOfSpikes,\
-        'number of spikes corresponds to their frequency: '
+        'number of spikes corresponds to their frequency'
 
 

--- a/memristive_spinal_cord/afferents/frequency/test_generator.py
+++ b/memristive_spinal_cord/afferents/frequency/test_generator.py
@@ -17,31 +17,28 @@ if __name__ == '__main__':
     assert len(sys.argv) == 3, '2 arguments needed simulation time and interval'
     testTime = int(sys.argv[1])
     testInterval = int(sys.argv[2])
-else:
-    testTime = 1
-    testInterval = 20
 
-testGenerator = TestGenerator()
-frequencyList = testGenerator.generate(testTime, testInterval)
-spikeList = frequencyList.generate_spikes()
+    testGenerator = TestGenerator()
+    frequencyList = testGenerator.generate(testTime, testInterval)
+    spikeList = frequencyList.generate_spikes()
 
-numberOfIntervals = testTime * 1000 // testInterval
-assert numberOfIntervals == len(frequencyList), 'frequency list size must be equal to the number of intervals'
+    numberOfIntervals = testTime * 1000 // testInterval
+    assert numberOfIntervals == len(frequencyList), 'frequency list size must be equal to the number of intervals'
 
-# storage for number of spikes per interval
-spikesPerInterval = [0] * numberOfIntervals
+    # storage for number of spikes per interval
+    spikesPerInterval = [0] * numberOfIntervals
 
-# collecting number of spikes per interval
-for spikeTime in spikeList:
-    spikeIndex = int(spikeTime / testInterval)
-    spikesPerInterval[spikeIndex] += 1
-print('Spikes per interval: ' + str(spikesPerInterval))
+    # collecting number of spikes per interval
+    for spikeTime in spikeList:
+        spikeIndex = int(spikeTime / testInterval)
+        spikesPerInterval[spikeIndex] += 1
+    print('Spikes per interval: ' + str(spikesPerInterval))
 
-# assert that number of spikes corresponds to their frequency
-acceptableErrorNumberOfSpikes = 2
-for i in range(numberOfIntervals):
-    intervalFrequency = frequencyList.list[i] / numberOfIntervals * testTime
-    assert math.fabs(intervalFrequency - spikesPerInterval[i]) < acceptableErrorNumberOfSpikes,\
-        'number of spikes corresponds to their frequency'
+    # assert that number of spikes corresponds to their frequency
+    acceptableErrorNumberOfSpikes = 2
+    for i in range(numberOfIntervals):
+        intervalFrequency = frequencyList.list[i] / numberOfIntervals * testTime
+        assert math.fabs(intervalFrequency - spikesPerInterval[i]) < acceptableErrorNumberOfSpikes,\
+            'number of spikes corresponds to their frequency'
 
 


### PR DESCRIPTION
The script requires 2 arguments for working: time (seconds) and interval (milliseconds).
For example `python3 test_generator.py 1 20`

For the reason of correctly imports the line
`sys.path.insert(0, '/'.join(os.getcwd().split('/')[:-3]))`
was inserted in `test_generator.py` before import of the FrequencyListGenerator.
This doesn't satisfy PEP8, but works correctly either in PyCharm or in command line.
Two another PEP8-like ways are working only in one of two choices.